### PR TITLE
Update PHP and WordPress versions in CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.1', '8.2']
-                wp-versions: ['6.8', '6.7']
+                php-versions: ['7.4', '8.2', '8.4']
+                wp-versions: ['6.9']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:

--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -12,8 +12,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['7.4', '8.1', '8.2']
-                wp-versions: ['6.8', '6.7']
+                php-versions: ['7.4', '8.2', '8.4']
+                wp-versions: ['6.9']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* テスト環境のPHPバージョンをアップデート（8.1を削除、8.4を追加）
* テスト環境のWordPressバージョンをアップデート（6.9に統一）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->