### PR TITLE
[ 開発環境 ] 一括登録パネルのインライン CSS / JS を外部ファイルへ分離

### DIFF
--- a/assets/css/admin-bulk-create-panel.css
+++ b/assets/css/admin-bulk-create-panel.css
@@ -1,0 +1,50 @@
+/**
+ * 給与明細一覧画面の「給与テンプレートから一括登録」パネル用スタイル。
+ *
+ * inc/salary-template/class-bvsl-bulk-create-from-template.php の
+ * インラインスタイルを外部化したもの。挙動は変えていない。
+ */
+
+/* パネル全体（折りたたみコンテナ） */
+.bvsl-bulk-create {
+	margin: 16px 0;
+	padding: 12px 16px;
+	background: #fff;
+	border: 1px solid #ccd0d4;
+	border-left: 4px solid #2271b1;
+}
+
+/* 折りたたみ見出し */
+.bvsl-bulk-create > summary {
+	cursor: pointer;
+	font-weight: 600;
+	font-size: 14px;
+	padding: 4px 0;
+}
+
+/* パネル本体（summary の下のコンテンツ領域） */
+.bvsl-bulk-create__body {
+	padding-top: 12px;
+}
+
+/* テンプレ件数説明（先頭の段落のマージン詰め） */
+.bvsl-bulk-create__lead {
+	margin-top: 0;
+}
+
+/* 生成件数の目安テキスト */
+.bvsl-bulk-create__summary {
+	margin: 0;
+}
+
+/* 補足説明（重複スキップなどの注意文） */
+.bvsl-bulk-create__note {
+	margin: 6px 0 0;
+	color: #555;
+}
+
+/* 上限件数超過の警告メッセージ */
+.bvsl-bulk-create__warning {
+	margin: 6px 0 0;
+	color: #b32d2e;
+}

--- a/assets/js/admin-bulk-create-panel.js
+++ b/assets/js/admin-bulk-create-panel.js
@@ -1,0 +1,85 @@
+/**
+ * 給与明細一覧画面の「給与テンプレートから一括登録」パネル用スクリプト。
+ *
+ * - 支給分セレクトの選択値に応じて生成件数の目安テキストを更新する。
+ * - フォーム送信時に最終確認のダイアログを出す。
+ *
+ * PHP 側からは bvslBulkCreatePanel として以下を渡す（wp_localize_script）:
+ *   - templateCount: 公開中の給与テンプレ件数（数値）
+ *   - i18n: { selectTerm, summary, confirm } の翻訳済み文字列
+ *
+ * 元は class-bvsl-bulk-create-from-template.php にインラインで記述していたものを
+ * 外部ファイルへ分離したもの。挙動は変えていない。
+ */
+( function () {
+	'use strict';
+
+	var form = document.getElementById( 'bvsl-bulk-create-form' );
+	if ( ! form ) {
+		return;
+	}
+
+	var termSel = document.getElementById( 'bvsl-bulk-term' );
+	var summary = document.getElementById( 'bvsl-bulk-summary' );
+
+	// PHP から渡された設定を取り出す。未定義時は安全側に倒してフォールバック。
+	var data  = ( typeof window.bvslBulkCreatePanel !== 'undefined' ) ? window.bvslBulkCreatePanel : {};
+	var i18n  = data.i18n || { selectTerm: '', summary: '', confirm: '' };
+	// 公開テンプレ件数は PHP 側で確定済みの値を埋め込む。
+	var templateCount = parseInt( data.templateCount, 10 );
+	if ( isNaN( templateCount ) ) {
+		templateCount = 0;
+	}
+
+	/**
+	 * 翻訳テンプレートの %1$d / %2$s を順に置換する（sprintf 風）。
+	 *
+	 * @param {string} tpl  テンプレート文字列。
+	 * @param {number} n    %1$d に入れる件数。
+	 * @param {string} term %2$s に入れる支給分名。
+	 * @return {string} 置換後の文字列。
+	 */
+	function format( tpl, n, term ) {
+		return tpl.replace( '%1$d', n ).replace( '%2$s', term );
+	}
+
+	/**
+	 * 現在選択されている支給分の表示テキストを返す。
+	 *
+	 * @return {string} 選択中なら option のテキスト、未選択なら空文字。
+	 */
+	function termText() {
+		if ( termSel && termSel.value && termSel.options[ termSel.selectedIndex ] ) {
+			return termSel.options[ termSel.selectedIndex ].text;
+		}
+		return '';
+	}
+
+	// 件数表示の更新。テンプレ件数は固定で、支給分を選んだら文言を 1 文に揃える。
+	function updateSummary() {
+		var term = termText();
+		if ( '' === term ) {
+			summary.textContent = i18n.selectTerm;
+		} else {
+			summary.textContent = format( i18n.summary, templateCount, term );
+		}
+	}
+
+	if ( termSel ) {
+		termSel.addEventListener( 'change', updateSummary );
+	}
+
+	// 送信前の最終確認。
+	form.addEventListener( 'submit', function ( e ) {
+		var term = termText();
+		if ( '' === term ) {
+			// 支給分未選択は HTML 側の required で弾かれるはずだが念のため。
+			return;
+		}
+		if ( ! window.confirm( format( i18n.confirm, templateCount, term ) ) ) {
+			e.preventDefault();
+		}
+	} );
+
+	updateSummary();
+} )();

--- a/inc/salary-template/class-bvsl-bulk-create-from-template.php
+++ b/inc/salary-template/class-bvsl-bulk-create-from-template.php
@@ -67,8 +67,74 @@ class BVSL_Bulk_Create_From_Template {
 		add_action( 'admin_notices', array( __CLASS__, 'render_panel' ), 1 );
 		// パネル送信後の結果通知。
 		add_action( 'admin_notices', array( __CLASS__, 'render_result_notice' ) );
+		// 一括登録パネル用の CSS / JS を給与明細一覧画面でのみ読み込む。
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
 		// admin-post.php エンドポイント。
 		add_action( 'admin_post_' . self::ACTION, array( __CLASS__, 'handle' ) );
+	}
+
+	/**
+	 * 一括登録パネル用の CSS / JS を読み込む。
+	 *
+	 * 給与明細（salary）一覧画面（hook_suffix: edit-salary）でのみ読み込む。
+	 * ファイルの更新時刻をバージョンに使うことで、ブラウザキャッシュの破棄を自動化する。
+	 *
+	 * @param string $hook_suffix 現在の管理画面の hook suffix。
+	 * @return void
+	 */
+	public static function enqueue_assets( $hook_suffix ) {
+		// 給与明細一覧画面（edit.php?post_type=salary）の hook suffix のみ対象。
+		if ( 'edit-salary' !== $hook_suffix ) {
+			return;
+		}
+		// 念のため画面判定でもガード（権限のないユーザーには読ませない）。
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// プラグインのルート（bill-vektor-salary.php がある場所）を基準にパスを組み立てる。
+		// __DIR__ は inc/salary-template/ なので、2 階層上がプラグインのルート。
+		$plugin_dir   = dirname( __DIR__, 2 );
+		$plugin_file  = $plugin_dir . '/bill-vektor-salary.php';
+		$css_rel_path = 'assets/css/admin-bulk-create-panel.css';
+		$js_rel_path  = 'assets/js/admin-bulk-create-panel.js';
+		$css_abs_path = $plugin_dir . '/' . $css_rel_path;
+		$js_abs_path  = $plugin_dir . '/' . $js_rel_path;
+
+		// バージョン文字列はファイルの mtime を使う（既存 enqueue 実装と揃える）。
+		$css_version = file_exists( $css_abs_path ) ? (string) filemtime( $css_abs_path ) : false;
+		$js_version  = file_exists( $js_abs_path ) ? (string) filemtime( $js_abs_path ) : false;
+
+		wp_enqueue_style(
+			'bvsl-admin-bulk-create-panel',
+			plugins_url( $css_rel_path, $plugin_file ),
+			array(),
+			$css_version
+		);
+
+		wp_enqueue_script(
+			'bvsl-admin-bulk-create-panel',
+			plugins_url( $js_rel_path, $plugin_file ),
+			array(),
+			$js_version,
+			true
+		);
+
+		// 旧インラインスクリプトで PHP から JS に渡していた値を localize で渡す。
+		// 公開テンプレ件数はパネル描画時に確定するため、ここでも同じ取得関数を使う。
+		$template_count = count( self::get_target_templates() );
+		wp_localize_script(
+			'bvsl-admin-bulk-create-panel',
+			'bvslBulkCreatePanel',
+			array(
+				'templateCount' => $template_count,
+				'i18n'          => array(
+					'selectTerm' => __( '支給分を選んでください。', 'bill-vektor-salary' ),
+					'summary'    => __( '公開中のテンプレート %1$d 件を「%2$s」で下書き作成します。', 'bill-vektor-salary' ),
+					'confirm'    => __( '公開中のテンプレート %1$d 件を「%2$s」で下書き作成します。よろしいですか？', 'bill-vektor-salary' ),
+				),
+			)
+		);
 	}
 
 	/**
@@ -169,11 +235,11 @@ class BVSL_Bulk_Create_From_Template {
 
 		$action_url = admin_url( 'admin-post.php' );
 		?>
-		<details class="bvsl-bulk-create" <?php echo $is_open ? 'open' : ''; ?> style="margin: 16px 0; padding: 12px 16px; background:#fff; border:1px solid #ccd0d4; border-left: 4px solid #2271b1;">
-			<summary style="cursor:pointer; font-weight:600; font-size:14px; padding: 4px 0;">
+		<details class="bvsl-bulk-create" <?php echo $is_open ? 'open' : ''; ?>>
+			<summary>
 				<?php echo esc_html__( '給与テンプレートから一括登録', 'bill-vektor-salary' ); ?>
 			</summary>
-			<div style="padding-top: 12px;">
+			<div class="bvsl-bulk-create__body">
 
 			<?php if ( ! $has_templates ) : ?>
 				<?php // テンプレ 0 件時はフォームを出さず、登録案内のみ大きく出す。 ?>
@@ -198,7 +264,7 @@ class BVSL_Bulk_Create_From_Template {
 					<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME ); ?>
 					<input type="hidden" name="action" value="<?php echo esc_attr( self::ACTION ); ?>" />
 
-					<p style="margin-top:0;">
+					<p class="bvsl-bulk-create__lead">
 						<?php
 						printf(
 							/* translators: %d: 公開中の給与テンプレ件数 */
@@ -228,14 +294,14 @@ class BVSL_Bulk_Create_From_Template {
 									<?php echo esc_html__( '生成件数の目安', 'bill-vektor-salary' ); ?>
 								</th>
 								<td>
-									<p id="bvsl-bulk-summary" style="margin:0;">
+									<p id="bvsl-bulk-summary" class="bvsl-bulk-create__summary">
 										<?php echo esc_html__( '支給分を選んでください。', 'bill-vektor-salary' ); ?>
 									</p>
-									<p style="margin:6px 0 0; color:#555;">
+									<p class="bvsl-bulk-create__note">
 										<?php echo esc_html__( '生成された給与明細はすべて下書きとして登録されます。同一スタッフの同一支給分の明細が既にある場合は自動でスキップされます。スタッフ未設定のテンプレートもスキップされます。', 'bill-vektor-salary' ); ?>
 									</p>
 									<?php if ( $template_count > self::MAX_TEMPLATE_COUNT ) : ?>
-										<p style="margin:6px 0 0; color:#b32d2e;">
+										<p class="bvsl-bulk-create__warning">
 											<?php
 											printf(
 												/* translators: 1: 上限件数 2: 公開中テンプレ件数 */
@@ -257,65 +323,6 @@ class BVSL_Bulk_Create_From_Template {
 						</button>
 					</p>
 				</form>
-
-				<script>
-				( function() {
-					var form = document.getElementById( 'bvsl-bulk-create-form' );
-					if ( ! form ) {
-						return;
-					}
-					var termSel = document.getElementById( 'bvsl-bulk-term' );
-					var summary = document.getElementById( 'bvsl-bulk-summary' );
-
-					// 翻訳テンプレート（1 文化、%1$d / %2$s をフロントで sprintf 風に置換）。
-					var i18n = {
-						selectTerm: <?php echo wp_json_encode( __( '支給分を選んでください。', 'bill-vektor-salary' ) ); ?>,
-						summary:    <?php echo wp_json_encode( __( '公開中のテンプレート %1$d 件を「%2$s」で下書き作成します。', 'bill-vektor-salary' ) ); ?>,
-						confirm:    <?php echo wp_json_encode( __( '公開中のテンプレート %1$d 件を「%2$s」で下書き作成します。よろしいですか？', 'bill-vektor-salary' ) ); ?>
-					};
-					// 公開テンプレ件数は PHP 側で確定済みの値を埋め込む。
-					var templateCount = <?php echo (int) $template_count; ?>;
-
-					function format( tpl, n, term ) {
-						return tpl.replace( '%1$d', n ).replace( '%2$s', term );
-					}
-
-					function termText() {
-						if ( termSel && termSel.value && termSel.options[ termSel.selectedIndex ] ) {
-							return termSel.options[ termSel.selectedIndex ].text;
-						}
-						return '';
-					}
-
-					// 件数表示の更新。テンプレ件数は固定で、支給分を選んだら文言を 1 文に揃える。
-					function updateSummary() {
-						var term = termText();
-						if ( '' === term ) {
-							summary.textContent = i18n.selectTerm;
-						} else {
-							summary.textContent = format( i18n.summary, templateCount, term );
-						}
-					}
-
-					if ( termSel ) {
-						termSel.addEventListener( 'change', updateSummary );
-					}
-
-					// 送信前の最終確認。
-					form.addEventListener( 'submit', function ( e ) {
-						var term = termText();
-						if ( '' === term ) {
-							// 支給分未選択は HTML 側の required で弾かれるはずだが念のため。
-							return;
-						}
-						if ( ! window.confirm( format( i18n.confirm, templateCount, term ) ) ) {
-							e.preventDefault();
-						}
-					} );
-
-					updateSummary();
-				} )();
-				</script>
 			<?php endif; ?>
 
 			</div>

--- a/inc/salary-template/class-bvsl-bulk-create-from-template.php
+++ b/inc/salary-template/class-bvsl-bulk-create-from-template.php
@@ -76,15 +76,23 @@ class BVSL_Bulk_Create_From_Template {
 	/**
 	 * 一括登録パネル用の CSS / JS を読み込む。
 	 *
-	 * 給与明細（salary）一覧画面（hook_suffix: edit-salary）でのみ読み込む。
+	 * 給与明細（salary）一覧画面でのみ読み込む。
+	 * admin_enqueue_scripts に渡される $hook_suffix は pagenow ベース（'edit.php' など）で、
+	 * post_type の情報を含まないため、現在のスクリーン ID（'edit-salary'）でも判定する。
 	 * ファイルの更新時刻をバージョンに使うことで、ブラウザキャッシュの破棄を自動化する。
 	 *
-	 * @param string $hook_suffix 現在の管理画面の hook suffix。
+	 * @param string $hook_suffix 現在の管理画面の hook suffix（'edit.php' など）。
 	 * @return void
 	 */
 	public static function enqueue_assets( $hook_suffix ) {
-		// 給与明細一覧画面（edit.php?post_type=salary）の hook suffix のみ対象。
-		if ( 'edit-salary' !== $hook_suffix ) {
+		// 投稿一覧系の画面（edit.php）以外は早期 return。
+		if ( 'edit.php' !== $hook_suffix ) {
+			return;
+		}
+		// $hook_suffix は post_type を区別しないため、スクリーン ID で salary 一覧かどうか判定する。
+		// admin_enqueue_scripts は current_screen フック以降に発火するため get_current_screen() が利用可能。
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $screen || 'edit-salary' !== $screen->id ) {
 			return;
 		}
 		// 念のため画面判定でもガード（権限のないユーザーには読ませない）。

--- a/inc/salary-template/class-bvsl-bulk-create-from-template.php
+++ b/inc/salary-template/class-bvsl-bulk-create-from-template.php
@@ -102,8 +102,10 @@ class BVSL_Bulk_Create_From_Template {
 		$js_abs_path  = $plugin_dir . '/' . $js_rel_path;
 
 		// バージョン文字列はファイルの mtime を使う（既存 enqueue 実装と揃える）。
-		$css_version = file_exists( $css_abs_path ) ? (string) filemtime( $css_abs_path ) : false;
-		$js_version  = file_exists( $js_abs_path ) ? (string) filemtime( $js_abs_path ) : false;
+		// ファイル不在時のフォールバックも既存 bvsl_admin_enqueue_scripts() に合わせて '1.0.1' を使う。
+		// false を渡すと WP コアのバージョンが付与されてしまう副作用があるため文字列固定にする。
+		$css_version = file_exists( $css_abs_path ) ? (string) filemtime( $css_abs_path ) : '1.0.1';
+		$js_version  = file_exists( $js_abs_path ) ? (string) filemtime( $js_abs_path ) : '1.0.1';
 
 		wp_enqueue_style(
 			'bvsl-admin-bulk-create-panel',


### PR DESCRIPTION
## 概要

PR #48 で給与テンプレート一括登録機能を実装した際、単一用途パネル向けに CSS / JS をインラインで記述していました。社内レビュー（安藤・植草）で「現状は単一用途のため許容、機能拡張時に外部化を検討する」と整理されていたものを、issue #49 として外部化する対応です。

挙動は一切変えていない、純粋なリファクタリングです。

Closes #49

## 変更内容

### 新規ファイル

- `assets/css/admin-bulk-create-panel.css` — 一括登録パネル用スタイル
- `assets/js/admin-bulk-create-panel.js` — 一括登録パネル用スクリプト

### 修正ファイル

- `inc/salary-template/class-bvsl-bulk-create-from-template.php`
  - `render_panel()` 内のインライン CSS（`style=\"...\"` 属性）を BEM 風クラス（`bvsl-bulk-create__body` / `__lead` / `__summary` / `__note` / `__warning`）へ置換
  - `render_panel()` 内の `<script>` ブロックを丸ごと削除し、外部 JS で置き換え
  - `enqueue_assets()` メソッドを新設し、`admin_enqueue_scripts` フックで CSS / JS を読み込み

## 実装ポイント

### enqueue 条件

- `\$hook_suffix === 'edit-salary'`（給与明細一覧画面）でのみ読み込み
- `current_user_can( 'manage_options' )` でガード（パネル本体と同じ権限要件）

### PHP → JS への値の受け渡し

旧インライン JS では `<?php echo wp_json_encode(...) ?>` で翻訳文字列を、`<?php echo (int) \$template_count ?>` で件数を直接埋め込んでいました。これを `wp_localize_script` 経由に変更:

\`\`\`php
wp_localize_script(
    'bvsl-admin-bulk-create-panel',
    'bvslBulkCreatePanel',
    array(
        'templateCount' => \$template_count,
        'i18n'          => array(
            'selectTerm' => __( '...', 'bill-vektor-salary' ),
            'summary'    => __( '...', 'bill-vektor-salary' ),
            'confirm'    => __( '...', 'bill-vektor-salary' ),
        ),
    )
);
\`\`\`

JS 側は `window.bvslBulkCreatePanel` から読み出し。ロジック（件数表示更新・送信前 confirm）は完全に同一です。

### バージョン文字列

既存 `bvsl_admin_enqueue_scripts()`（bill-vektor-salary.php:46）の流儀に揃え、`filemtime()` をベースに、ファイル不在時のフォールバックは `'1.0.1'` を使用。`false` を渡すと WP コアバージョンが自動付与される副作用があるため、文字列固定としています。

## 確認手順

### 前提条件

- 親テーマ「BillVektor」が有効化されていること
- 投稿タイプ `salary-template`（給与テンプレート）の公開投稿が 1 件以上あること
- タクソノミー `salary-term`（支給分）のタームが 1 件以上あること
- 管理者権限（`manage_options`）でログインしていること

### 手順

1. 管理画面 > 給与明細（一覧画面 `edit.php?post_type=salary`）を開く
   → ✓ 上部に「給与テンプレートから一括登録」パネルが従来通りの見た目で表示される（左に青いボーダー、白背景の枠）
2. ブラウザの開発者ツールで対象パネルの DOM を確認する
   → ✓ `<details class=\"bvsl-bulk-create\">` に `style=\"\"` 属性が残っていない
   → ✓ `<script>` ブロックがインラインで埋め込まれていない
3. 開発者ツールの Network タブをリロードして読み込まれているリソースを確認する
   → ✓ `admin-bulk-create-panel.css` と `admin-bulk-create-panel.js` が `?ver=<filemtime>` 付きで読み込まれている
4. 別ページ（例: 投稿一覧 `edit.php`、固定ページ一覧 `edit.php?post_type=page`、ダッシュボード）を開いて Network を確認する
   → ✓ `admin-bulk-create-panel.css` / `admin-bulk-create-panel.js` が読み込まれていない（給与明細一覧でのみ読み込み）
5. パネル内の「支給分」セレクトを変更する
   → ✓ 「生成件数の目安」のテキストが「公開中のテンプレート N 件を「（選んだ支給分名）」で下書き作成します。」に更新される
6. 支給分を選んだ状態で「一括登録（下書きで作成）」をクリックする
   → ✓ 「公開中のテンプレート N 件を「（支給分名）」で下書き作成します。よろしいですか？」の confirm ダイアログが出る
7. confirm でキャンセルを選ぶ
   → ✓ 送信されない（同じ画面に留まる）
8. 再度クリックして OK で送信
   → ✓ 給与明細が下書きとして一括生成され、結果通知が表示される
9. 給与テンプレートを 0 件にして同画面を開く
   → ✓ 「給与テンプレートを作成」ボタンの案内が表示される（フォームは出ない）
10. 編集者ロール（`manage_options` を持たない）でログインして給与明細一覧を開く
    → ✓ パネル自体が表示されず、CSS / JS も読み込まれない（Network で確認）

## スクリーンショット

純粋な内部リファクタリングで表示・UI は一切変更していないため省略します。インライン CSS をクラス指定に置換したのみで、適用される値は完全に同じです。

## changelog

readme.txt の更新は **不要** と判断しました。理由:

- 挙動を一切変えていない純粋なリファクタリング（エンドユーザーには無影響）
- `[ 開発環境 ]` カテゴリは readme.txt（エンドユーザー向け）には記載しないルール（`changelog.md` 参照）
- CHANGELOG.md は当プラグインに存在しない

## 参考

- 元 issue: #49
- 経緯となった PR: #48（給与テンプレート一括登録機能の追加）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 給与テンプレートからの一括登録パネルをインライン実装から分離し、見た目と構造をクラスベースのスタイルに整理しました。既存の処理は変更ありません。
* **New Features**
  * 管理画面のパネルで選択に応じた件数表示の自動更新と、送信時の最終確認ダイアログをクライアント側で動作させるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->