### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -6,9 +6,11 @@ on:
             - master
             - develop
             - ^feature/.+
+        types: [opened, reopened, labeled, synchronize]
 
 jobs:
     php_unit:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## 概要
GitHub Actions の消費削減のため、PHPUnit テストの実行を `run-ci` ラベル付き PR のときのみに限定します。当ワークフローは元々 push トリガーを持たず PR のみで実行されていましたが、ラベルによるゲーティングがなく全 PR で実行されていたため、`run-ci` ラベルでの gating を追加します。

## 変更内容
対象ファイル: `.github/workflows/php_unit_test.yml`

- `on.pull_request` に `types: [opened, reopened, labeled, synchronize]` を追加（ラベル付与を検知）
- `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加し、`run-ci` ラベルが付いた PR のときのみ実行
- （push トリガーは元々無いため変更なし）

## 確認手順
1. ラベル無しの PR ではワークフローが起動しないこと
2. `run-ci` ラベルを付与すると起動すること
3. push（ブランチへの直接 push）では起動しないこと
4. リリース時（該当する場合）は従来どおりテストが実行されること

CI 設定のみの変更で、プラグインの動作には影響ありません。

関連: vektor-inc/multi-repo-tasks#24
